### PR TITLE
Change to using object lookups rather than array lookups

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,13 @@
 module.exports = intersect;
 
 function intersect (a, b) {
-  var res = [];
+  var res = [],
+      temp = {};
   for (var i = 0; i < a.length; i++) {
-    if (indexOf(b, a[i]) > -1) res.push(a[i]);
+    temp[a[i]] = true;
+  }
+  for (var i = 0; i < b.length; i++) {
+      if (temp[b[i]]) res.push(b[i]);
   }
   return res;
-}
-
-function indexOf(arr, el) {
-  for (var i = 0; i < arr.length; i++) {
-    if (arr[i] === el) return i;
-  }
-  return -1;
 }


### PR DESCRIPTION
This change makes the intersection O(n+m) rather than O(n*m), resulting in incredibly [significant](http://jsperf.com/array-lookup-vs-object-lookup-intersect) speed ups for large arrays.
