### PR TITLE
add test for compliance

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -16,8 +16,8 @@ test('big', function (t) {
 test('compliance', function(t) {
   for (var algo in intersect) {
     if (intersect.hasOwnProperty(algo) && typeof intersect[algo] === 'function') {
-      t.deepEqual(intersect([2], [2,2,2]), intersect[algo]([2], [2,2,2]), algo + '-complies-1');
-      t.deepEqual(intersect([2,2,2], [2]), intersect[algo]([2,2,2], [2]), algo + '-complies-2');
+      t.deepEqual(intersect[algo]([2], [2,2,2]), intersect([2], [2,2,2]), algo + '-complies-1');
+      t.deepEqual(intersect[algo]([2,2,2], [2]), intersect([2,2,2], [2]), algo + '-complies-2');
     }
   }
   t.end();


### PR DESCRIPTION
Adds a test that runs through all the algorithms provided and check they behave the same way as the standard implementation. Assumes that all algorithms are provided as functions set as properties on the main intersect function exported in the module.

Might be worth adding an additional test to this fixture to ensure that the the standard implementation continues to function the same way it does now, in case future changes cause a heisenbug for anyone depending on the behavior intersect provides right now.

Addresses #5
