### PR TITLE
Use null-prototype for faster lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function intersect (a, b) {
 
 intersect.big = function(a, b) {
   var ret = [];
-  var temp = {};
+  var temp = Object.create(null);
   
   for (var i = 0; i < b.length; i++) {
     temp[b[i]] = true;


### PR DESCRIPTION
Given that the `intersect.big` function is designed to work with big arrays, this should provide a little speed improvement. I'm not sure what happens with compatibility. I would've liked to see if this changes benchmarks but there isn't anything to run benchmarks.
